### PR TITLE
♻️ Improve error handling and enhance test coverage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 phpunit.xml export-ignore
+phpunit.xml.dist export-ignore
 phpstan.neon.dist export-ignore
 pint.json export-ignore
 rector.php export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,128 @@
+name: Tests
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    php-tests:
+        name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
+
+        runs-on: ubuntu-latest
+
+        timeout-minutes: 5
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php: [8.2, 8.3, 8.4, 8.5]
+                laravel: [^10.0, ^11.0, ^12.0, ^13.0]
+                stability: [prefer-stable]
+                include:
+                    - laravel: ^10.0
+                      testbench: ^8.0
+                    - laravel: ^11.0
+                      testbench: ^9.1.14
+                    - laravel: ^12.0
+                      testbench: ^10.0
+                    - laravel: ^13.0
+                      testbench: ^11.0
+                    - php: 8.2
+                      laravel: ^10.0
+                      testbench: ^8.0
+                      stability: prefer-lowest
+                    - php: 8.2
+                      laravel: ^11.0
+                      testbench: ^9.1.14
+                      stability: prefer-lowest
+                    - php: 8.2
+                      laravel: ^12.0
+                      testbench: ^10.0
+                      stability: prefer-lowest
+                    - php: 8.3
+                      laravel: ^13.0
+                      testbench: ^11.0
+                      stability: prefer-lowest
+                exclude:
+                    - php: 8.2
+                      laravel: ^13.0
+                    - php: 8.5
+                      laravel: ^10.0
+                    - php: 8.5
+                      laravel: ^11.0
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: ${{ matrix.php }}
+                extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
+                coverage: none
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache composer dependencies
+              uses: actions/cache@v5
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-php${{ matrix.php }}-laravel${{ matrix.laravel }}-${{ matrix.stability }}-${{ hashFiles('composer.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-php${{ matrix.php }}-laravel${{ matrix.laravel }}-${{ matrix.stability }}-
+                      ${{ runner.os }}-composer-php${{ matrix.php }}-laravel${{ matrix.laravel }}-
+
+            - name: Install dependencies
+              run: |
+                  composer require --dev "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+            - name: Execute tests
+              run: |
+                  vendor/bin/phpunit
+
+    static-analysis:
+        name: Static analysis
+
+        runs-on: ubuntu-latest
+
+        timeout-minutes: 5
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: 8.3
+                extensions: curl, mbstring, zip
+                coverage: none
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache composer dependencies
+              uses: actions/cache@v5
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-static-analysis-${{ hashFiles('composer.json') }}
+                  restore-keys: ${{ runner.os }}-composer-static-analysis-
+
+            - name: Install dependencies
+              run: composer update --prefer-dist --no-interaction
+
+            - name: Check code style
+              run: composer pint:check
+
+            - name: Run static analysis
+              run: composer test:analyze

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,12 @@ on:
         branches: [master]
     pull_request:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
     php-tests:
@@ -51,6 +54,8 @@ jobs:
                 exclude:
                     - php: 8.2
                       laravel: ^13.0
+                    - php: 8.4
+                      laravel: ^10.0
                     - php: 8.5
                       laravel: ^10.0
                     - php: 8.5
@@ -64,7 +69,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                 php-version: ${{ matrix.php }}
-                extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
+                extensions: curl, mbstring, zip
                 coverage: none
 
             - name: Get composer cache directory
@@ -83,14 +88,59 @@ jobs:
             - name: Install dependencies
               run: |
                   composer require --dev "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                  composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+                  composer update --${{ matrix.stability }} ${{ matrix.stability == 'prefer-lowest' && '--prefer-stable' || '' }} --prefer-dist --no-interaction
 
             - name: Execute tests
-              run: |
-                  vendor/bin/phpunit
+              run: composer test:no-coverage
 
     static-analysis:
-        name: Static analysis
+        name: Static analysis - Laravel ${{ matrix.laravel }}
+
+        runs-on: ubuntu-latest
+
+        timeout-minutes: 5
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - laravel: ^10.0
+                      testbench: ^8.0
+                    - laravel: ^13.0
+                      testbench: ^11.0
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: 8.3
+                extensions: curl, mbstring, zip
+                coverage: none
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache composer dependencies
+              uses: actions/cache@v5
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-static-analysis-laravel${{ matrix.laravel }}-${{ hashFiles('composer.json') }}
+                  restore-keys: ${{ runner.os }}-composer-static-analysis-laravel${{ matrix.laravel }}-
+
+            - name: Install dependencies
+              run: |
+                  composer require --dev "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer update --prefer-dist --no-interaction
+
+            - name: Run static analysis
+              run: composer test:analyze
+
+    code-style:
+        name: Code style
 
         runs-on: ubuntu-latest
 
@@ -115,14 +165,11 @@ jobs:
               uses: actions/cache@v5
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-static-analysis-${{ hashFiles('composer.json') }}
-                  restore-keys: ${{ runner.os }}-composer-static-analysis-
+                  key: ${{ runner.os }}-composer-code-style-${{ hashFiles('composer.json') }}
+                  restore-keys: ${{ runner.os }}-composer-code-style-
 
             - name: Install dependencies
               run: composer update --prefer-dist --no-interaction
 
             - name: Check code style
               run: composer pint:check
-
-            - name: Run static analysis
-              run: composer test:analyze

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ First of all, thanks for taking the time to contribute 🎉
   - `git rebase upstream/main`
   - `git push origin main --force-with-lease`
 - Early and unfinished pull requests are encouraged. This means the changes can be discussed and changes can be suggested where needed. Please make sure to mark the pull request as draft in that case. 
-- 
 - Make sure the tests pass once you mark your pull request as finished
 
 ## Commit messages and pull request titles

--- a/README.md
+++ b/README.md
@@ -18,25 +18,24 @@ Add a new channel to the `config/logging.php` file
 'channels' => [
     ...
     'betterstack' => [
-        'driver'         => 'monolog',
-        'level'          => env('LOG_LEVEL', 'debug'),
-        'handler'        => \Goedemiddag\BetterStackLogs\BetterStackHandler::class,
-        'handler_with'   => [
+        'driver'       => 'monolog',
+        'level'        => env('LOG_LEVEL', 'debug'),
+        'enabled'      => env('BETTERSTACK_LOGS_ENABLED', true),
+        'handler'      => \Goedemiddag\BetterStackLogs\BetterStackHandler::class,
+        'handler_with' => [
             'sourceToken' => env('BETTERSTACK_LOGS_SOURCE_TOKEN'),
             'host'        => env('BETTERSTACK_LOGS_HOST'),
         ],
     ],
     ...
-]   
+]
 ```
 
-Set the default log channel to `betterstack` or add it to the `stack` channel
+Set the default log channel to `betterstack` or add it to the `stack` channel.
 
-Add the following to your `.env` file
-
+Add the following to your `.env` file:
 
 ```sh
 BETTERSTACK_LOGS_SOURCE_TOKEN=your-source-token
 BETTERSTACK_LOGS_HOST=your-ingestion-host
 ```
-

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
   },
   "require-dev": {
     "phpstan/phpstan": "^1.9",
-    "laravel/pint": "^1.16"
+    "laravel/pint": "^1.16",
+    "phpunit/phpunit": "^10.5|^11.0",
+    "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
   },
   "require-dev": {
-    "phpstan/phpstan": "^1.9",
+    "phpstan/phpstan": "^2.0",
     "laravel/pint": "^1.16",
     "phpunit/phpunit": "^10.5|^11.0",
     "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0"

--- a/config/betterstack-logs.php
+++ b/config/betterstack-logs.php
@@ -1,5 +1,6 @@
 <?php
 
+use Goedemiddag\BetterStackLogs\BetterStackClient;
 use Goedemiddag\BetterStackLogs\BetterStackHandler;
 use Goedemiddag\BetterStackLogs\Processors\LaravelProcessor;
 use Monolog\Processor\HostnameProcessor;
@@ -19,9 +20,9 @@ return [
         'sourceToken' => env('BETTERSTACK_LOGS_SOURCE_TOKEN'),
         'host'        => env('BETTERSTACK_LOGS_HOST'),
 
-        'connectTimeout' => (int) env('BETTERSTACK_LOGS_CONNECT_TIMEOUT', 0),
-        'timeout'        => (int) env('BETTERSTACK_LOGS_TIMEOUT', 0),
-        'retries'        => (int) env('BETTERSTACK_LOGS_RETRIES', 0),
+        'connectTimeout' => (int) env('BETTERSTACK_LOGS_CONNECT_TIMEOUT', BetterStackClient::DEFAULT_CONNECT_TIMEOUT),
+        'timeout'        => (int) env('BETTERSTACK_LOGS_TIMEOUT', BetterStackClient::DEFAULT_TIMEOUT),
+        'retries'        => (int) env('BETTERSTACK_LOGS_RETRIES', BetterStackClient::DEFAULT_RETRIES),
     ],
 
     'processors' => [

--- a/config/betterstack-logs.php
+++ b/config/betterstack-logs.php
@@ -12,10 +12,16 @@ return [
     'driver' => 'monolog',
     'level'  => env('LOG_LEVEL', 'debug'),
 
+    'enabled' => env('BETTERSTACK_LOGS_ENABLED', true),
+
     'handler'      => BetterStackHandler::class,
     'handler_with' => [
         'sourceToken' => env('BETTERSTACK_LOGS_SOURCE_TOKEN'),
         'host'        => env('BETTERSTACK_LOGS_HOST'),
+
+        'connectTimeout' => (int) env('BETTERSTACK_LOGS_CONNECT_TIMEOUT', 0),
+        'timeout'        => (int) env('BETTERSTACK_LOGS_TIMEOUT', 0),
+        'retries'        => (int) env('BETTERSTACK_LOGS_RETRIES', 0),
     ],
 
     'processors' => [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,5 @@
 parameters:
     level: 9
+    phpVersion: 80200
     paths:
         - src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,7 @@
 parameters:
     level: 9
-    phpVersion: 80200
+    phpVersion:
+        min: 80200
+        max: 80599
     paths:
         - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory=".phpunit.cache"
+    colors="true"
+    failOnRisky="true"
+    failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="Goedemiddag Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/BetterStackClient.php
+++ b/src/BetterStackClient.php
@@ -22,7 +22,7 @@ class BetterStackClient
         private readonly ?int $retries = null,
     ) {}
 
-    public function send(mixed $data): void
+    public function send(string $data): void
     {
         if (!$this->hasSourceToken()) {
             return;

--- a/src/BetterStackClient.php
+++ b/src/BetterStackClient.php
@@ -14,7 +14,7 @@ class BetterStackClient
     private const DEFAULT_RETRIES = 2;
 
     public function __construct(
-        private readonly ?string $sourceToken,
+        private readonly string $sourceToken,
         private readonly ?string $host,
         private CurlHandle|false $handle = false,
         private readonly ?int $connectTimeout = null,
@@ -57,7 +57,7 @@ class BetterStackClient
 
     private function hasSourceToken(): bool
     {
-        return trim((string) $this->sourceToken) !== '';
+        return trim($this->sourceToken) !== '';
     }
 
     private function initCurlHandle(): void

--- a/src/BetterStackClient.php
+++ b/src/BetterStackClient.php
@@ -4,29 +4,60 @@ namespace Goedemiddag\BetterStackLogs;
 
 use CurlHandle;
 use Monolog\Handler\Curl\Util;
+use Throwable;
 
 class BetterStackClient
 {
     private const URL = 'https://in.logs.betterstack.com';
+    private const DEFAULT_CONNECT_TIMEOUT = 2;
+    private const DEFAULT_TIMEOUT = 5;
+    private const DEFAULT_RETRIES = 2;
 
     public function __construct(
-        private readonly string $sourceToken,
-        private ?string $host,
+        private readonly ?string $sourceToken,
+        private readonly ?string $host,
         private CurlHandle|false $handle = false,
+        private readonly ?int $connectTimeout = null,
+        private readonly ?int $timeout = null,
+        private readonly ?int $retries = null,
     ) {}
 
     public function send(mixed $data): void
     {
+        if (!$this->hasSourceToken()) {
+            return;
+        }
+
         if (!$this->handle) {
             $this->initCurlHandle();
         }
 
-        if ($this->handle instanceof CurlHandle) {
-            curl_setopt($this->handle, CURLOPT_POSTFIELDS, $data);
-            curl_setopt($this->handle, CURLOPT_RETURNTRANSFER, true);
-
-            Util::execute($this->handle);
+        if (!$this->handle instanceof CurlHandle) {
+            return;
         }
+
+        curl_setopt($this->handle, CURLOPT_POSTFIELDS, $data);
+        curl_setopt($this->handle, CURLOPT_RETURNTRANSFER, true);
+
+        try {
+            Util::execute($this->handle, $this->positiveOrDefault($this->retries, self::DEFAULT_RETRIES));
+        } catch (Throwable $e) {
+            error_log('[betterstack-logs] failed to deliver logs: ' . $e->getMessage());
+        }
+    }
+
+    private function positiveOrDefault(?int $value, int $default): int
+    {
+        if ($value === null || $value <= 0) {
+            return $default;
+        }
+
+        return $value;
+    }
+
+    private function hasSourceToken(): bool
+    {
+        return trim((string) $this->sourceToken) !== '';
     }
 
     private function initCurlHandle(): void
@@ -42,6 +73,8 @@ class BetterStackClient
             curl_setopt($this->handle, CURLOPT_URL, $this->host ? "https://$this->host" : self::URL);
             curl_setopt($this->handle, CURLOPT_POST, true);
             curl_setopt($this->handle, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($this->handle, CURLOPT_CONNECTTIMEOUT, $this->positiveOrDefault($this->connectTimeout, self::DEFAULT_CONNECT_TIMEOUT));
+            curl_setopt($this->handle, CURLOPT_TIMEOUT, $this->positiveOrDefault($this->timeout, self::DEFAULT_TIMEOUT));
         }
     }
 }

--- a/src/BetterStackClient.php
+++ b/src/BetterStackClient.php
@@ -9,9 +9,9 @@ use Throwable;
 class BetterStackClient
 {
     private const URL = 'https://in.logs.betterstack.com';
-    private const DEFAULT_CONNECT_TIMEOUT = 2;
-    private const DEFAULT_TIMEOUT = 5;
-    private const DEFAULT_RETRIES = 2;
+    public const DEFAULT_CONNECT_TIMEOUT = 2;
+    public const DEFAULT_TIMEOUT = 5;
+    public const DEFAULT_RETRIES = 2;
 
     public function __construct(
         private readonly string $sourceToken,

--- a/src/BetterStackHandler.php
+++ b/src/BetterStackHandler.php
@@ -4,19 +4,58 @@ namespace Goedemiddag\BetterStackLogs;
 
 use Monolog\Handler\BufferHandler;
 use Monolog\Level;
+use Monolog\LogRecord;
 
 class BetterStackHandler extends BufferHandler
 {
-    public function __construct(string $sourceToken, ?string $host = null, int|string|Level $level = Level::Debug)
-    {
-        $handler = new SynchronousBetterStackHandler($sourceToken, $host, $level);
+    private bool $active;
+
+    public function __construct(
+        ?string $sourceToken = null,
+        ?string $host = null,
+        int|string|Level $level = Level::Debug,
+        ?bool $enabled = null,
+        ?BetterStackClient $client = null,
+        ?int $connectTimeout = null,
+        ?int $timeout = null,
+        ?int $retries = null,
+    ) {
+        $handler = new SynchronousBetterStackHandler(
+            sourceToken   : $sourceToken,
+            host          : $host,
+            level         : $level,
+            enabled       : $enabled,
+            client        : $client,
+            connectTimeout: $connectTimeout,
+            timeout       : $timeout,
+            retries       : $retries,
+        );
 
         parent::__construct(
             handler: $handler,
             level  : $level,
         );
 
-        // add synchronous handler processors to buffer handler
+        $this->active = $handler->isActive();
+
         $this->pushProcessor(fn($record) => $handler->processRecord($record));
+    }
+
+    public function isHandling(LogRecord $record): bool
+    {
+        if (!$this->active) {
+            return false;
+        }
+
+        return parent::isHandling($record);
+    }
+
+    public function handle(LogRecord $record): bool
+    {
+        if (!$this->active) {
+            return false;
+        }
+
+        return parent::handle($record);
     }
 }

--- a/src/SynchronousBetterStackHandler.php
+++ b/src/SynchronousBetterStackHandler.php
@@ -11,19 +11,39 @@ use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Level;
 use Monolog\LogRecord;
+use Throwable;
 
 class SynchronousBetterStackHandler extends AbstractProcessingHandler
 {
     private BetterStackClient $client;
 
+    private bool $active;
+
     public function __construct(
-        string $sourceToken,
-        ?string $host,
+        ?string $sourceToken = null,
+        ?string $host = null,
         int|string|Level $level = Level::Debug,
+        ?bool $enabled = null,
+        ?BetterStackClient $client = null,
+        ?int $connectTimeout = null,
+        ?int $timeout = null,
+        ?int $retries = null,
     ) {
         parent::__construct($level);
 
-        $this->client = new BetterStackClient($sourceToken, $host);
+        $this->active = self::resolveEnabled($enabled) && trim((string) $sourceToken) !== '';
+
+        $this->client = $client ?? new BetterStackClient(
+            sourceToken   : $sourceToken,
+            host          : $host,
+            connectTimeout: $connectTimeout,
+            timeout       : $timeout,
+            retries       : $retries,
+        );
+
+        if (!$this->active) {
+            return;
+        }
 
         /** @var array<callable> $processors */
         $processors = (new Collection(Arr::wrap(Config::get('logging.channels.betterstack.processors'))))
@@ -43,16 +63,53 @@ class SynchronousBetterStackHandler extends AbstractProcessingHandler
         $this->processors = $processors;
     }
 
+    private static function resolveEnabled(?bool $enabled): bool
+    {
+        if ($enabled !== null) {
+            return $enabled;
+        }
+
+        $configured = Config::get('logging.channels.betterstack.enabled');
+
+        return (bool) ($configured ?? true);
+    }
+
+    public function isHandling(LogRecord $record): bool
+    {
+        if (!$this->active) {
+            return false;
+        }
+
+        return parent::isHandling($record);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
     protected function write(LogRecord $record): void
     {
-        $this->client->send($record->formatted);
+        try {
+            $this->client->send($record->formatted);
+        } catch (Throwable $e) {
+            $this->reportFailure($e);
+        }
     }
 
     public function handleBatch(array $records): void
     {
-        $formattedRecords = $this->getFormatter()->formatBatch($records);
+        if (!$this->active) {
+            return;
+        }
 
-        $this->client->send($formattedRecords);
+        try {
+            $formattedRecords = $this->getFormatter()->formatBatch($records);
+
+            $this->client->send($formattedRecords);
+        } catch (Throwable $e) {
+            $this->reportFailure($e);
+        }
     }
 
     protected function getDefaultFormatter(): FormatterInterface
@@ -68,5 +125,10 @@ class SynchronousBetterStackHandler extends AbstractProcessingHandler
     public function processRecord(LogRecord $record): LogRecord
     {
         return parent::processRecord($record);
+    }
+
+    private function reportFailure(Throwable $e): void
+    {
+        error_log('[betterstack-logs] failed to deliver logs: ' . $e->getMessage());
     }
 }

--- a/src/SynchronousBetterStackHandler.php
+++ b/src/SynchronousBetterStackHandler.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
-use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Level;
 use Monolog\LogRecord;
@@ -90,6 +89,10 @@ class SynchronousBetterStackHandler extends AbstractProcessingHandler
 
     protected function write(LogRecord $record): void
     {
+        if (!is_string($record->formatted)) {
+            return;
+        }
+
         try {
             $this->client->send($record->formatted);
         } catch (Throwable $e) {
@@ -112,12 +115,12 @@ class SynchronousBetterStackHandler extends AbstractProcessingHandler
         }
     }
 
-    protected function getDefaultFormatter(): FormatterInterface
+    protected function getDefaultFormatter(): BetterStackFormatter
     {
         return new BetterStackFormatter;
     }
 
-    public function getFormatter(): FormatterInterface
+    public function getFormatter(): BetterStackFormatter
     {
         return $this->getDefaultFormatter();
     }

--- a/src/SynchronousBetterStackHandler.php
+++ b/src/SynchronousBetterStackHandler.php
@@ -34,7 +34,7 @@ class SynchronousBetterStackHandler extends AbstractProcessingHandler
         $this->active = self::resolveEnabled($enabled) && trim((string) $sourceToken) !== '';
 
         $this->client = $client ?? new BetterStackClient(
-            sourceToken   : $sourceToken,
+            sourceToken   : (string) $sourceToken,
             host          : $host,
             connectTimeout: $connectTimeout,
             timeout       : $timeout,

--- a/tests/BetterStackHandlerTest.php
+++ b/tests/BetterStackHandlerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Goedemiddag\BetterStackLogs\Tests;
+
+use DateTimeImmutable;
+use Goedemiddag\BetterStackLogs\BetterStackHandler;
+use Goedemiddag\BetterStackLogs\SynchronousBetterStackHandler;
+use Goedemiddag\BetterStackLogs\Tests\Doubles\RecordingClient;
+use Illuminate\Support\Facades\Config;
+use Monolog\Handler\BufferHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+
+class BetterStackHandlerTest extends TestCase
+{
+    private function record(string $message = 'a message'): LogRecord
+    {
+        return new LogRecord(
+            datetime: new DateTimeImmutable,
+            channel : 'testing',
+            level   : Level::Info,
+            message : $message,
+        );
+    }
+
+    /**
+     * @return array<string, array{0: ?string}>
+     */
+    public static function blankTokens(): array
+    {
+        return [
+            'null token'       => [null],
+            'empty token'      => [''],
+            'whitespace token' => ['   '],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('blankTokens')]
+    public function it_constructs_without_error_when_the_source_token_is_blank(?string $token): void
+    {
+        $handler = new BetterStackHandler($token);
+
+        $this->assertInstanceOf(BetterStackHandler::class, $handler);
+    }
+
+    #[Test]
+    #[DataProvider('blankTokens')]
+    public function it_never_reaches_the_client_when_the_source_token_is_blank(?string $token): void
+    {
+        $client = new RecordingClient;
+
+        $handler = new BetterStackHandler($token, null, Level::Debug, null, $client);
+
+        $this->assertFalse($handler->handle($this->record()));
+
+        $handler->close();
+
+        $this->assertSame([], $client->sent);
+    }
+
+    #[Test]
+    public function it_never_reaches_the_client_when_disabled_even_with_a_valid_token(): void
+    {
+        $client = new RecordingClient;
+
+        $handler = new BetterStackHandler('a-valid-token', null, Level::Debug, false, $client);
+
+        $this->assertFalse($handler->handle($this->record()));
+
+        $handler->close();
+
+        $this->assertSame([], $client->sent);
+    }
+
+    #[Test]
+    public function it_reads_the_enabled_flag_from_the_channel_config(): void
+    {
+        Config::set('logging.channels.betterstack.enabled', false);
+
+        $client = new RecordingClient;
+
+        $handler = new BetterStackHandler('a-valid-token', null, Level::Debug, null, $client);
+
+        $handler->handle($this->record());
+        $handler->close();
+
+        $this->assertSame([], $client->sent);
+    }
+
+    #[Test]
+    public function the_constructor_argument_overrides_the_config_key(): void
+    {
+        Config::set('logging.channels.betterstack.enabled', false);
+
+        $client = new RecordingClient;
+
+        $handler = new BetterStackHandler('a-valid-token', null, Level::Debug, true, $client);
+
+        $handler->handle($this->record());
+        $handler->close();
+
+        $this->assertCount(1, $client->sent);
+    }
+
+    #[Test]
+    public function it_defaults_to_enabled_when_the_config_key_is_absent_entirely(): void
+    {
+        Config::set('logging', []);
+
+        $this->assertNull(Config::get('logging.channels.betterstack.enabled'));
+
+        $client = new RecordingClient;
+
+        $handler = new BetterStackHandler('a-valid-token', null, Level::Debug, null, $client);
+
+        $handler->handle($this->record());
+        $handler->close();
+
+        $this->assertCount(1, $client->sent, 'An upgrade without config changes must keep shipping logs.');
+    }
+
+    #[Test]
+    public function it_sends_a_record_to_the_client_when_enabled_with_a_valid_token(): void
+    {
+        $client = new RecordingClient;
+
+        $handler = new BetterStackHandler('a-valid-token', null, Level::Debug, true, $client);
+
+        $handler->handle($this->record('hello betterstack'));
+        $handler->close();
+
+        $this->assertCount(1, $client->sent);
+        $this->assertStringContainsString('hello betterstack', (string) $client->sent[0]);
+    }
+
+    #[Test]
+    public function is_handling_reports_false_when_the_channel_is_off(): void
+    {
+        $disabledByToken = new BetterStackHandler(null);
+        $disabledByFlag = new BetterStackHandler('a-valid-token', null, Level::Debug, false);
+        $active = new BetterStackHandler('a-valid-token', null, Level::Debug, true);
+
+        $this->assertFalse($disabledByToken->isHandling($this->record()));
+        $this->assertFalse($disabledByFlag->isHandling($this->record()));
+        $this->assertTrue($active->isHandling($this->record()));
+    }
+
+    private function bufferSizeOf(BetterStackHandler $handler): int
+    {
+        return (int) (new ReflectionProperty(BufferHandler::class, 'bufferSize'))->getValue($handler);
+    }
+
+    #[Test]
+    public function a_disabled_handler_buffers_nothing(): void
+    {
+        $handler = new BetterStackHandler('a-valid-token', null, Level::Debug, false, new RecordingClient);
+
+        $handler->handle($this->record());
+
+        $this->assertSame(0, $this->bufferSizeOf($handler), 'A disabled channel must not buffer for the shutdown flush.');
+    }
+
+    #[Test]
+    public function an_active_handler_still_buffers(): void
+    {
+        $handler = new BetterStackHandler('a-valid-token', null, Level::Debug, true, new RecordingClient);
+
+        $handler->handle($this->record());
+
+        $this->assertSame(1, $this->bufferSizeOf($handler));
+    }
+
+    #[Test]
+    public function the_synchronous_handler_ignores_handle_batch_when_the_channel_is_off(): void
+    {
+        $client = new RecordingClient;
+
+        $handler = new SynchronousBetterStackHandler('a-valid-token', null, Level::Debug, false, $client);
+
+        $handler->handleBatch([$this->record()]);
+
+        $this->assertSame([], $client->sent);
+    }
+
+    #[Test]
+    public function the_synchronous_handler_is_inactive_when_the_channel_is_off(): void
+    {
+        $this->assertFalse((new SynchronousBetterStackHandler(null, null))->isActive());
+        $this->assertFalse((new SynchronousBetterStackHandler('', null))->isActive());
+        $this->assertFalse((new SynchronousBetterStackHandler('a-valid-token', null, Level::Debug, false))->isActive());
+        $this->assertTrue((new SynchronousBetterStackHandler('a-valid-token', null))->isActive());
+    }
+}

--- a/tests/BetterStackHandlerTest.php
+++ b/tests/BetterStackHandlerTest.php
@@ -134,7 +134,7 @@ class BetterStackHandlerTest extends TestCase
         $handler->close();
 
         $this->assertCount(1, $client->sent);
-        $this->assertStringContainsString('hello betterstack', (string) $client->sent[0]);
+        $this->assertStringContainsString('hello betterstack', $client->sent[0]);
     }
 
     #[Test]

--- a/tests/ChannelResolutionTest.php
+++ b/tests/ChannelResolutionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Goedemiddag\BetterStackLogs\Tests;
+
+use Goedemiddag\BetterStackLogs\BetterStackHandler;
+use Goedemiddag\BetterStackLogs\Tests\Concerns\CapturesErrorLog;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+
+class ChannelResolutionTest extends TestCase
+{
+    use CapturesErrorLog;
+    private const DEAD_HOST = '127.0.0.1:1';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->captureErrorLog();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->releaseErrorLog();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function the_channel_resolves_and_accepts_writes_without_a_source_token(): void
+    {
+        Config::set('logging.channels.betterstack.handler_with.sourceToken', null);
+        Config::set('logging.channels.betterstack.handler_with.host', self::DEAD_HOST);
+
+        $logger = Log::channel('betterstack');
+
+        $this->assertInstanceOf(
+            BetterStackHandler::class,
+            $logger->getLogger()->getHandlers()[0],
+            'The channel should resolve normally, not fall back to the emergency logger.',
+        );
+
+        $logger->info('no source token configured');
+
+        $logger->getLogger()->close();
+
+        $this->assertSame('', $this->capturedErrorLog(), 'A blank token must perform no network I/O.');
+    }
+
+    #[Test]
+    public function the_channel_performs_no_network_io_when_disabled_with_a_valid_token(): void
+    {
+        Config::set('logging.channels.betterstack.enabled', false);
+        Config::set('logging.channels.betterstack.handler_with.sourceToken', 'a-valid-token');
+        Config::set('logging.channels.betterstack.handler_with.host', self::DEAD_HOST);
+
+        $logger = Log::channel('betterstack');
+
+        $logger->info('should go nowhere');
+        $logger->getLogger()->close();
+
+        $this->assertSame('', $this->capturedErrorLog(), 'A disabled channel must perform no network I/O.');
+    }
+
+    #[Test]
+    public function the_channel_still_attempts_delivery_when_enabled_with_a_valid_token(): void
+    {
+        Config::set('logging.channels.betterstack.handler_with.sourceToken', 'a-valid-token');
+        Config::set('logging.channels.betterstack.handler_with.host', self::DEAD_HOST);
+
+        $logger = Log::channel('betterstack');
+
+        $logger->info('should be attempted');
+        $logger->getLogger()->close();
+
+        $this->assertStringContainsString(
+            'failed to deliver logs',
+            $this->capturedErrorLog(),
+            'The default configuration must still ship logs; only the attempt failing is expected here.',
+        );
+    }
+
+    #[Test]
+    public function it_survives_an_action_level_wrapped_handler_when_disabled(): void
+    {
+        Config::set('logging.channels.betterstack.enabled', false);
+        Config::set('logging.channels.betterstack.handler_with.sourceToken', 'a-valid-token');
+        Config::set('logging.channels.betterstack.handler_with.host', self::DEAD_HOST);
+        Config::set('logging.channels.betterstack.action_level', 'debug');
+
+        $logger = Log::channel('betterstack');
+
+        $logger->error('wrapped in a FingersCrossedHandler');
+        $logger->getLogger()->close();
+
+        $this->assertSame(
+            '',
+            $this->capturedErrorLog(),
+            'FingersCrossedHandler calls handle() directly, bypassing isHandling().',
+        );
+    }
+}

--- a/tests/ChannelResolutionTest.php
+++ b/tests/ChannelResolutionTest.php
@@ -2,8 +2,10 @@
 
 namespace Goedemiddag\BetterStackLogs\Tests;
 
+use Goedemiddag\BetterStackLogs\BetterStackClient;
 use Goedemiddag\BetterStackLogs\BetterStackHandler;
 use Goedemiddag\BetterStackLogs\Tests\Concerns\CapturesErrorLog;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\Test;
@@ -79,6 +81,14 @@ class ChannelResolutionTest extends TestCase
             $this->capturedErrorLog(),
             'The default configuration must still ship logs; only the attempt failing is expected here.',
         );
+    }
+
+    #[Test]
+    public function the_container_cannot_build_a_client_of_its_own(): void
+    {
+        $this->expectException(BindingResolutionException::class);
+
+        $this->app->make(BetterStackClient::class);
     }
 
     #[Test]

--- a/tests/Concerns/CapturesErrorLog.php
+++ b/tests/Concerns/CapturesErrorLog.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Goedemiddag\BetterStackLogs\Tests\Concerns;
+
+trait CapturesErrorLog
+{
+    private string $errorLogPath;
+
+    private string|false $previousErrorLog;
+
+    private string|false $previousLogErrors;
+
+    protected function captureErrorLog(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'betterstack-error-log-');
+
+        $this->errorLogPath = $path === false ? '' : $path;
+
+        $this->previousErrorLog = ini_get('error_log');
+        $this->previousLogErrors = ini_get('log_errors');
+
+        ini_set('error_log', $this->errorLogPath);
+        ini_set('log_errors', '1');
+    }
+
+    protected function releaseErrorLog(): void
+    {
+        ini_set('error_log', $this->previousErrorLog === false ? '' : $this->previousErrorLog);
+        ini_set('log_errors', $this->previousLogErrors === false ? '1' : $this->previousLogErrors);
+
+        if (is_file($this->errorLogPath)) {
+            unlink($this->errorLogPath);
+        }
+    }
+
+    protected function capturedErrorLog(): string
+    {
+        return is_file($this->errorLogPath) ? (string) file_get_contents($this->errorLogPath) : '';
+    }
+}

--- a/tests/Doubles/RecordingClient.php
+++ b/tests/Doubles/RecordingClient.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Goedemiddag\BetterStackLogs\Tests\Doubles;
+
+use Goedemiddag\BetterStackLogs\BetterStackClient;
+
+class RecordingClient extends BetterStackClient
+{
+    /** @var array<int, mixed> */
+    public array $sent = [];
+
+    public function __construct()
+    {
+        parent::__construct('recording-token', null);
+    }
+
+    public function send(mixed $data): void
+    {
+        $this->sent[] = $data;
+    }
+}

--- a/tests/Doubles/RecordingClient.php
+++ b/tests/Doubles/RecordingClient.php
@@ -6,7 +6,7 @@ use Goedemiddag\BetterStackLogs\BetterStackClient;
 
 class RecordingClient extends BetterStackClient
 {
-    /** @var array<int, mixed> */
+    /** @var array<int, string> */
     public array $sent = [];
 
     public function __construct()
@@ -14,7 +14,7 @@ class RecordingClient extends BetterStackClient
         parent::__construct('recording-token', null);
     }
 
-    public function send(mixed $data): void
+    public function send(string $data): void
     {
         $this->sent[] = $data;
     }

--- a/tests/Doubles/ThrowingClient.php
+++ b/tests/Doubles/ThrowingClient.php
@@ -14,7 +14,7 @@ class ThrowingClient extends BetterStackClient
         parent::__construct('throwing-token', null);
     }
 
-    public function send(mixed $data): void
+    public function send(string $data): void
     {
         $this->attempts++;
 

--- a/tests/Doubles/ThrowingClient.php
+++ b/tests/Doubles/ThrowingClient.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Goedemiddag\BetterStackLogs\Tests\Doubles;
+
+use Goedemiddag\BetterStackLogs\BetterStackClient;
+use RuntimeException;
+
+class ThrowingClient extends BetterStackClient
+{
+    public int $attempts = 0;
+
+    public function __construct()
+    {
+        parent::__construct('throwing-token', null);
+    }
+
+    public function send(mixed $data): void
+    {
+        $this->attempts++;
+
+        throw new RuntimeException("Curl error (code 60): SSL: no alternative certificate subject name matches target hostname 'in.logs.betterstack.com'");
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Goedemiddag\BetterStackLogs\Tests;
+
+use Goedemiddag\BetterStackLogs\BetterStackLogsServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+abstract class TestCase extends Orchestra
+{
+    /**
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            BetterStackLogsServiceProvider::class,
+        ];
+    }
+}

--- a/tests/TransportFailureTest.php
+++ b/tests/TransportFailureTest.php
@@ -99,7 +99,7 @@ class TransportFailureTest extends TestCase
     #[Test]
     public function the_client_makes_no_request_at_all_when_the_source_token_is_blank(): void
     {
-        $client = new BetterStackClient(null, self::DEAD_HOST);
+        $client = new BetterStackClient('', self::DEAD_HOST);
 
         $client->send('{"message":"hello"}');
 

--- a/tests/TransportFailureTest.php
+++ b/tests/TransportFailureTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Goedemiddag\BetterStackLogs\Tests;
+
+use DateTimeImmutable;
+use Goedemiddag\BetterStackLogs\BetterStackClient;
+use Goedemiddag\BetterStackLogs\BetterStackHandler;
+use Goedemiddag\BetterStackLogs\SynchronousBetterStackHandler;
+use Goedemiddag\BetterStackLogs\Tests\Concerns\CapturesErrorLog;
+use Goedemiddag\BetterStackLogs\Tests\Doubles\ThrowingClient;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\Attributes\Test;
+
+class TransportFailureTest extends TestCase
+{
+    use CapturesErrorLog;
+    private const DEAD_HOST = '127.0.0.1:1';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->captureErrorLog();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->releaseErrorLog();
+
+        parent::tearDown();
+    }
+
+    private function record(string $message = 'a message'): LogRecord
+    {
+        return new LogRecord(
+            datetime: new DateTimeImmutable,
+            channel : 'testing',
+            level   : Level::Info,
+            message : $message,
+        );
+    }
+
+    #[Test]
+    public function a_throwing_transport_does_not_propagate_out_of_handle_batch(): void
+    {
+        $client = new ThrowingClient;
+
+        $handler = new SynchronousBetterStackHandler('a-valid-token', null, Level::Debug, true, $client);
+
+        $handler->handleBatch([$this->record()]);
+
+        $this->assertSame(1, $client->attempts);
+        $this->assertStringContainsString('failed to deliver logs', $this->capturedErrorLog());
+    }
+
+    #[Test]
+    public function a_throwing_transport_does_not_propagate_out_of_write(): void
+    {
+        $client = new ThrowingClient;
+
+        $handler = new SynchronousBetterStackHandler('a-valid-token', null, Level::Debug, true, $client);
+
+        $handler->handle($this->record());
+
+        $this->assertSame(1, $client->attempts);
+        $this->assertStringContainsString('failed to deliver logs', $this->capturedErrorLog());
+    }
+
+    #[Test]
+    public function a_throwing_transport_does_not_propagate_out_of_the_buffered_shutdown_flush(): void
+    {
+        $client = new ThrowingClient;
+
+        $handler = new BetterStackHandler('a-valid-token', null, Level::Debug, true, $client);
+
+        $handler->handle($this->record());
+
+        $handler->close();
+
+        $this->assertSame(1, $client->attempts);
+        $this->assertStringContainsString('failed to deliver logs', $this->capturedErrorLog());
+    }
+
+    #[Test]
+    public function the_client_swallows_a_real_curl_failure(): void
+    {
+        $client = new BetterStackClient('a-valid-token', self::DEAD_HOST);
+
+        $client->send('{"message":"hello"}');
+
+        $this->assertStringContainsString(
+            'failed to deliver logs',
+            $this->capturedErrorLog(),
+            'A real curl failure should be reported to error_log, not thrown.',
+        );
+    }
+
+    #[Test]
+    public function the_client_makes_no_request_at_all_when_the_source_token_is_blank(): void
+    {
+        $client = new BetterStackClient(null, self::DEAD_HOST);
+
+        $client->send('{"message":"hello"}');
+
+        $this->assertSame(
+            '',
+            $this->capturedErrorLog(),
+            'A blank token must short-circuit before curl_init(); reaching the dead host would have logged a failure.',
+        );
+    }
+}


### PR DESCRIPTION
**Problem:** Better Stack log delivery cannot currently be disabled when the package is installed. Leaving the token empty causes an exception, and test suites may still attempt to send logs to Better Stack.

For example, we have something like:

```php
Log::channel('betterstack')->debug('test');
```

Which will throw an error in tests:

```
Fatal error: Uncaught RuntimeException: Curl error (code 60): SSL: no alternative certificate subject name matches target hostname 'in.logs.betterstack.com' in /[path_to_project]/vendor/monolog/monolog/src/Monolog/Handler/Curl/Util.php:51
Stack trace: #0 /[path_to_project]/vendor/goedemiddag/betterstack-logs/src/BetterStackClient.php(28): Monolog\Handler\Curl\Util::execute(Object(CurlHandle))
```

**Solution:** A way to explicitly disable Better Stack log sending—especially for local and test environments—would prevent these failures.

```dotenv
# .env or .env.testing
BETTERSTACK_LOGS_ENABLED=false
```

```xml
# phpunit.xml
<env name="BETTERSTACK_LOGS_ENABLED" value="false"/>
```

Existing applications that do not have the `'enabled' => env('BETTERSTACK_LOGS_ENABLED', true)` line in their `betterstack.php` config will still keep working, since it always falls back to enabled.